### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,13 @@
             <artifactId>struts2-core</artifactId>
             <version>${struts2.version}</version>
         </dependency>
-
+        
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j2.version}</version>
+        </dependency>
+        
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>


### PR DESCRIPTION
Without an explicit log4j-api dependency, Maven is grabbing log4j-core-2.6.2 and log4j-api 2.5 and throwing a NoSuchMethodError when starting struts2 filter. Added explicit log4j-api dependency as described in [Maven documentation](https://logging.apache.org/log4j/2.x/maven-artifacts.html).
