### PR TITLE
there is not exists 2.5.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <struts2.version>2.5.12</struts2.version>
+        <struts2.version>2.5.10.1</struts2.version>
         <log4j2.version>2.8.2</log4j2.version>
     </properties>
 


### PR DESCRIPTION
ERROR Failed to execute goal on project action-chaining:Could not resolve dependencies for project org.apache.struts: action-chaining:war:1.0-SNAPSHOT:  Failure to find org.apache.stuts:struts2-core:jar:2.5.12 in https://repository.apache.org/content/groups/public/ was cached in the local repository, resolution will not be reattemped until the update interval of apche-public has elapsed or updates are forced