### PR TITLE
Add alternative way for custom TextProvider

### DIFF
--- a/text-provider/src/main/java/org/apache/struts_example/MyTextProviderFactory.java
+++ b/text-provider/src/main/java/org/apache/struts_example/MyTextProviderFactory.java
@@ -4,7 +4,10 @@ import com.opensymphony.xwork2.StrutsTextProviderFactory;
 import com.opensymphony.xwork2.TextProvider;
 
 import java.util.ResourceBundle;
-
+/** 
+ * Exdending the TextProviderFactory is optional, as Factory return the TextProvider class it gets as argument. 
+ * See struts.xml for example configuration without extending TextProviderFactory.
+ */
 public class MyTextProviderFactory extends StrutsTextProviderFactory {
 
     @Override

--- a/text-provider/src/main/resources/struts.xml
+++ b/text-provider/src/main/resources/struts.xml
@@ -15,10 +15,20 @@
   <bean type="com.opensymphony.xwork2.TextProviderFactory"
         class="org.apache.struts_example.MyTextProviderFactory"
         name="myTextProviderFactory"
-        scope="singleton"/>
-
+        scope="singleton"/>  
+  
   <constant name="struts.textProviderFactory" value="myTextProviderFactory"/>
-
+    
+  <!-- 
+  Alternatively, if you prefer to extend only TextProviderSupport, 
+  you can define the custrom TextProvider like this (see Struts v2.5.10 TextProvider Javadocs):
+  -->
+  <!--  
+  <bean class="com.company.MyTextProviderSupport" name="MyTextProviderSupport" 
+    type="com.opensymphony.xwork2.TextProvider" />
+  <constant name="struts.xworkTextProvider" value="MyTextProviderSupport" />
+  -->
+  
   <package name="default" extends="struts-default">
 
     <default-action-ref name="index"/>


### PR DESCRIPTION
Added [in comments] alternative way to extend Struts 2 TextProvider that seems simpler & faster to develop. It skips the need to extend TextProviderFactory.