### PR TITLE
Fix cve

### DIFF
--- a/mailreader/pom.xml
+++ b/mailreader/pom.xml
@@ -46,12 +46,18 @@
             <artifactId>struts-mailreader-dao</artifactId>
             <version>1.3.5</version>
         </dependency>
-        <!-- override transitive version from struts-mailreader-dao -->
+        <!-- begin: override transitive version from struts-mailreader-dao -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.9.4</version>
+        </dependency>
         <dependency>
             <groupId>commons-collections</groupId>
             <artifactId>commons-collections</artifactId>
             <version>3.2.2</version>
         </dependency>
+        <!-- end: override transitive version from struts-mailreader-dao -->
     </dependencies>
 
     <build>

--- a/mailreader/pom.xml
+++ b/mailreader/pom.xml
@@ -46,7 +46,12 @@
             <artifactId>struts-mailreader-dao</artifactId>
             <version>1.3.5</version>
         </dependency>
-
+        <!-- override transitive version from struts-mailreader-dao -->
+        <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+            <version>3.2.2</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
@lukaszlenart I know you are working on a replacement for the mailreader example within 
https://github.com/apache/struts-examples/pull/27 but maybe we can use those two changes as a quickfix for failing builds during org.owasp:dependency-check-maven

e.g. https://builds.apache.org/blue/organizations/jenkins/Struts-examples-JDK8-dependency-check/detail/Struts-examples-JDK8-dependency-check/10/pipeline

```
[ERROR] Failed to execute goal org.owasp:dependency-check-maven:5.2.2:check (default) on project mailreader: 
[ERROR] 
[ERROR] One or more dependencies were identified with vulnerabilities that have a CVSS score greater than or equal to '7.0': 

[ERROR] 
[ERROR] struts-mailreader-dao-1.3.5.jar: CVE-2016-1181, CVE-2013-2115, CVE-2016-1182, CVE-2014-0114, CVE-2015-0899
[ERROR] commons-beanutils-1.6.jar: CVE-2014-0114, CVE-2019-10086
[ERROR] commons-collections-2.1.jar: CVE-2015-6420, CVE-2017-15708
```