### PR TITLE
Fix typo in dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,9 @@
 # Basic dependabot.yml file with
-# minimum configuration for two package managers
+# minimum configuration for maven package manager
 
 version: 2
 updates:
-  # Enable version updates for Docker
+  # Enable version updates for Maven
   - package-ecosystem: "maven"
     directory: "/"
     # Check for updates once a week


### PR DESCRIPTION
Currently, `dependabot.yml` has a configuration for Maven package manager only.