### PR TITLE
Remove spring-framework-bom dependency from jasperreports example

### DIFF
--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -16,21 +16,8 @@
   <name>JasperReports Tutorial</name>
   <url>https://struts.apache.org/getting-started/jasper-reports-tutorial</url>
   <properties>
-    <spring.platformVersion>5.3.20</spring.platformVersion>
     <jasperreports.version>6.20.0</jasperreports.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.springframework</groupId>
-        <artifactId>spring-framework-bom</artifactId>
-        <version>${spring.platformVersion}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>


### PR DESCRIPTION
Hello

I removed the bom declaration as it was unnecessary.

It seems better to use the version set by the Struts 2 Spring plugin.

Please review.

thank you