### PR TITLE
Update struts.xml - Timer Interceptor is DEPRECATED

### DIFF
--- a/interceptors/src/main/resources/struts.xml
+++ b/interceptors/src/main/resources/struts.xml
@@ -20,10 +20,8 @@
 		<result name="input">register.jsp</result>
 	  </action>
 
-      <!-- for logger interceptor see: https://struts.apache.org/core-developers/logging-interceptor.html -->
       <!-- for timer interceptor see https://struts.apache.org/core-developers/timer-interceptor.html -->		
 	  <action name="register" class="org.apache.struts.register.action.Register" method="execute">
-	  		<interceptor-ref name="timer" />
 			<interceptor-ref name="logger" />
 			<interceptor-ref name="defaultStack">
 			   <param name="exception.logEnabled">true</param>


### PR DESCRIPTION
Timer Interceptor is DEPRECATED

Keeping it in `struts.xml` will cause exceptions.