### PR TITLE
jasperreports example - Jetty Upgrade to 12.x

### DIFF
--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -17,6 +17,7 @@
   <url>https://struts.apache.org/getting-started/jasper-reports-tutorial</url>
   <properties>
     <jasperreports.version>6.21.2</jasperreports.version>
+    <jetty-plugin.version>12.0.8</jetty-plugin.version>
   </properties>
 
   <dependencies>
@@ -68,8 +69,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty</groupId>
-        <artifactId>jetty-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee8</groupId>
+        <artifactId>jetty-ee8-maven-plugin</artifactId>
         <version>${jetty-plugin.version}</version>
         <configuration>
           <webApp>
@@ -77,8 +78,15 @@
           </webApp>
           <stopKey>CTRL+C</stopKey>
           <stopPort>8999</stopPort>
-          <scanIntervalSeconds>10</scanIntervalSeconds>
+          <scan>10</scan>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>xalan</groupId>
+            <artifactId>serializer</artifactId>
+            <version>2.7.3</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/jasperreports/src/main/java/org/apache/struts/example/jasperreports/service/JasperInitializer.java
+++ b/jasperreports/src/main/java/org/apache/struts/example/jasperreports/service/JasperInitializer.java
@@ -15,7 +15,9 @@ public class JasperInitializer implements InitializingBean, DisposableBean, Serv
 
   private static final Logger LOG = LogManager.getLogger(JasperInitializer.class);
 
-  private static final String COMPILED_JASPER_FILE = "/WEB-INF/jasper/our_compiled_template.jasper";
+  private static final String COMPILED_JASPER_PATH = "/WEB-INF/jasper/";
+
+  private static final String COMPILED_JASPER_FILENAME = "our_compiled_template.jasper";
 
   @Override
   public void afterPropertiesSet() throws Exception {
@@ -29,7 +31,7 @@ public class JasperInitializer implements InitializingBean, DisposableBean, Serv
                     throw new IllegalStateException("our_jasper_template.jrxml File not found.");
                   })
               .getFile(),
-          sc.getRealPath(COMPILED_JASPER_FILE));
+          sc.getRealPath(COMPILED_JASPER_PATH) + COMPILED_JASPER_FILENAME);
       LOG.info("=== End JasperReport compile ===");
     } catch (Exception e) {
       throw new IllegalStateException("Failed to compile, " + e.getMessage(), e);
@@ -43,7 +45,7 @@ public class JasperInitializer implements InitializingBean, DisposableBean, Serv
 
   @Override
   public void destroy() throws Exception {
-    File templteFile = new File(sc.getRealPath(COMPILED_JASPER_FILE));
+    File templteFile = new File(sc.getRealPath(COMPILED_JASPER_PATH) + COMPILED_JASPER_FILENAME);
     LOG.info(
         "=== Compiled JasperReport file ({}) delete result: {} ===",
         templteFile.getAbsolutePath(),


### PR DESCRIPTION
hello.

I upgraded the Jetty version of jasperreports example to 12.0.8 and checked the behaviour.

Even Jetty 12 version can be used as Servlet 4 (javax) if you use EE8 version, so I only changed the jasperreports example project that I had modified before.


## Changes

### ServletContext#getRealPath() behavior

In Jetty 9.4, `getRealPath("/not_exist_path")` of ServletContext returned a path string even if the path did not exist.

In Jetty 12, `getRealPath("/not_exist_path")` returns `null`. Because of this phenomenon, the main source code was also slightly modified.



### When running Jetty 12 Maven Plugin, it was necessary to add a dependency.

In Jetty 9.4, there was no special dependency to add, but in Jetty 12, `xalan:serializer` had to be added to the dependency.

```xml
<dependency>
  <groupId>xalan</groupId>
  <artifactId>serializer</artifactId>
  <version>2.7.3</version>
</dependency>
```

Without the above dependency, the below exception occurred.

```
java.lang.NoClassDefFoundError: org/apache/xml/serializer/OutputPropertiesFactory
```



thank you have a good day. 👍