### PR TITLE
Resolve execution issues after Struts2 7.0.x migration

### DIFF
--- a/jasperreports/pom.xml
+++ b/jasperreports/pom.xml
@@ -16,8 +16,9 @@
   <name>JasperReports Tutorial</name>
   <url>https://struts.apache.org/getting-started/jasper-reports-tutorial</url>
   <properties>
-    <jasperreports.version>7.0.2</jasperreports.version>
-    <jetty-plugin.version>12.0.18</jetty-plugin.version>
+    <jasperreports6.version>6.21.4</jasperreports6.version>
+    <jasperreports.version>${jasperreports6.version}</jasperreports.version>
+    <jetty-plugin.version>12.0.19</jetty-plugin.version>
   </properties>
 
   <dependencies>
@@ -55,8 +56,8 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.eclipse.jetty.ee8</groupId>
-        <artifactId>jetty-ee8-maven-plugin</artifactId>
+        <groupId>org.eclipse.jetty.ee10</groupId>
+        <artifactId>jetty-ee10-maven-plugin</artifactId>
         <version>${jetty-plugin.version}</version>
         <configuration>
           <webApp>

--- a/jasperreports/src/main/java/org/apache/struts/example/jasperreports/service/JasperInitializer.java
+++ b/jasperreports/src/main/java/org/apache/struts/example/jasperreports/service/JasperInitializer.java
@@ -1,9 +1,8 @@
 package org.apache.struts.example.jasperreports.service;
 
+import jakarta.servlet.ServletContext;
 import java.io.File;
 import java.util.Optional;
-
-import jakarta.servlet.ServletContext;
 import net.sf.jasperreports.engine.JasperCompileManager;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -46,10 +45,10 @@ public class JasperInitializer implements InitializingBean, DisposableBean, Serv
 
   @Override
   public void destroy() throws Exception {
-    File templteFile = new File(sc.getRealPath(COMPILED_JASPER_PATH) + COMPILED_JASPER_FILENAME);
+    File templateFile = new File(sc.getRealPath(COMPILED_JASPER_PATH) + COMPILED_JASPER_FILENAME);
     LOG.info(
         "=== Compiled JasperReport file ({}) delete result: {} ===",
-        templteFile.getAbsolutePath(),
-        templteFile.delete());
+        templateFile.getAbsolutePath(),
+        templateFile.delete());
   }
 }

--- a/jasperreports/src/main/resources/struts.xml
+++ b/jasperreports/src/main/resources/struts.xml
@@ -3,6 +3,8 @@
 
 <struts>
   <constant name="struts.devMode" value="true" />
+  <constant name="struts.allowlist.packageNames" value="org.apache.struts.example.jasperreports.model"/>
+
   <package name="default" extends="jasperreports-default">
     <default-action-ref name="index" />
 

--- a/jasperreports/src/main/webapp/WEB-INF/web.xml
+++ b/jasperreports/src/main/webapp/WEB-INF/web.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
-<web-app id="WebApp_ID" version="4.0" xmlns="http://xmlns.jcp.org/xml/ns/javaee" 
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee
-                             http://xmlns.jcp.org/xml/ns/javaee/web-app_4_0.xsd">
+<web-app id="WebApp_ID" version="6.0"
+  xmlns="https://jakarta.ee/xml/ns/jakartaee"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_0.xsd">
 
   <display-name>Jasper Reports Tutorial</display-name>
   <welcome-file-list>


### PR DESCRIPTION
1. Added `struts.allowlist.packageNames` configuration

2. Modified Jetty 12 Maven Plugin configuration for EE10

3. Downgraded JasperReports version to 6.x 
  the example's `our_jasper_template.jrxml` is not currently compatible with the JasperReports 7.x format.

5. Updated web.xml to Jakarta EE 10 namespace and Servlet 6.0 schema

6. Fixed minor typos


Thanks 👍